### PR TITLE
Hack to allow super- and subscript with no preceeding whitespace

### DIFF
--- a/ox-jira.el
+++ b/ox-jira.el
@@ -92,6 +92,9 @@
   "Replace anything we don't handle yet wiht a big red marker."
   (format "{color:red}Element of type '%s' not implemented!{color}" element-type))
 
+(defun ox-jira--text-transform-embeddable (transform-char contents)
+  (concat "{anchor}" transform-char contents transform-char))
+
 ;;; Transcode functions
 
 (defun ox-jira-bold (bold contents info)
@@ -277,13 +280,13 @@ contextual information."
   "Transcode SUBSCRIPT from Org to JIRA.
 CONTENTS is the text with subscript markup. INFO is a plist holding
 contextual information."
-  (format "~%s~" contents))
+  (ox-jira--text-transform-embeddable "~" contents))
 
 (defun ox-jira-superscript (superscript contents info)
   "Transcode SUPERSCRIPT from Org to JIRA.
 CONTENTS is the text with superscript markup. INFO is a plist holding
 contextual information."
-  (format "^%s^" contents))
+  (ox-jira--text-transform-embeddable "^" contents))
 
 (defun ox-jira-table (table contents info)
   "Transcode a TABLE element from Org to JIRA.

--- a/ox-jira.org
+++ b/ox-jira.org
@@ -171,6 +171,18 @@
        (format "{color:red}Element of type '%s' not implemented!{color}" element-type))
    #+END_SRC
 
+   Super^script and sub_script I often want at the end of words, with no
+   whitespace immediately before it. Unfortunately JIRA doesn't support that,
+   so we have to fake it. This function makes simple text transforms
+   "embeddable" by preceding them with an empty anchor. This is admittedly a
+   bit of a hack, but I haven't found anything better.
+
+   #+BEGIN_SRC emacs-lisp
+     (defun ox-jira--text-transform-embeddable (transform-char contents)
+       (concat "{anchor}" transform-char contents transform-char))
+   #+END_SRC
+
+
 ** Transcode Functions
 
    These functions do the actual translation to JIRA format. For this section
@@ -495,7 +507,7 @@
         "Transcode SUBSCRIPT from Org to JIRA.
       CONTENTS is the text with subscript markup. INFO is a plist holding
       contextual information."
-        (format "~%s~" contents))
+        (ox-jira--text-transform-embeddable "~" contents))
     #+END_SRC
 
 *** Superscript
@@ -505,7 +517,7 @@
         "Transcode SUPERSCRIPT from Org to JIRA.
       CONTENTS is the text with superscript markup. INFO is a plist holding
       contextual information."
-        (format "^%s^" contents))
+        (ox-jira--text-transform-embeddable "^" contents))
     #+END_SRC
 
 *** Table

--- a/test/ox-jira-test.el
+++ b/test/ox-jira-test.el
@@ -32,11 +32,13 @@
   (should (equal "this is *strong* text\n" (org-export-string-as "this is *strong* text" 'jira)))
   (should (equal "this is _emphasised_ text\n" (org-export-string-as "this is /emphasised/ text" 'jira)))
   (should (equal "this is +underlined+ text\n" (org-export-string-as "this is _underlined_ text" 'jira)))
-  (should (equal "this is super^scripted^ text\n" (org-export-string-as "this is super^scripted text" 'jira)))
-  (should (equal "this is sub~scripted~ text\n" (org-export-string-as "this is sub_scripted text" 'jira)))
   (should (equal "this is -deleted- text\n" (org-export-string-as "this is +deleted+ text" 'jira)))
   (should (equal "this is {{inline code}}\n" (org-export-string-as "this is ~inline code~" 'jira)))
   (should (equal "this is {{verbatim}} text\n" (org-export-string-as "this is =verbatim= text" 'jira))))
+
+(ert-deftest ox-jira-test/embeddable-text-effects ()
+  (should (equal "this is super{anchor}^scripted^ text\n" (org-export-string-as "this is super^scripted text" 'jira)))
+  (should (equal "this is sub{anchor}~scripted~ text\n" (org-export-string-as "this is sub_scripted text" 'jira))))
 
 (ert-deftest ox-jira-test/quotations ()
   (should (equal "{quote}

--- a/test/ox-jira-test.org
+++ b/test/ox-jira-test.org
@@ -77,11 +77,19 @@
        (should (equal "this is *strong* text\n" (org-export-string-as "this is *strong* text" 'jira)))
        (should (equal "this is _emphasised_ text\n" (org-export-string-as "this is /emphasised/ text" 'jira)))
        (should (equal "this is +underlined+ text\n" (org-export-string-as "this is _underlined_ text" 'jira)))
-       (should (equal "this is super^scripted^ text\n" (org-export-string-as "this is super^scripted text" 'jira)))
-       (should (equal "this is sub~scripted~ text\n" (org-export-string-as "this is sub_scripted text" 'jira)))
        (should (equal "this is -deleted- text\n" (org-export-string-as "this is +deleted+ text" 'jira)))
        (should (equal "this is {{inline code}}\n" (org-export-string-as "this is ~inline code~" 'jira)))
        (should (equal "this is {{verbatim}} text\n" (org-export-string-as "this is =verbatim= text" 'jira))))
+   #+END_SRC
+
+   Test that super^script and sub_script have empty anchor immediately
+   preceeding, so they can be tacked at the end of words without whitespace
+   immediately before it.
+
+   #+BEGIN_SRC emacs-lisp
+     (ert-deftest ox-jira-test/embeddable-text-effects ()
+       (should (equal "this is super{anchor}^scripted^ text\n" (org-export-string-as "this is super^scripted text" 'jira)))
+       (should (equal "this is sub{anchor}~scripted~ text\n" (org-export-string-as "this is sub_scripted text" 'jira))))
    #+END_SRC
 
    Quotations are a bit more elaborate, so let's test those separately. They


### PR DESCRIPTION
I often want super^script and sub_script at the end of words, with no whitespace immediately before it. Unfortunately JIRA doesn't support that, so we have to fake it. This is a bit of a hack, but I haven't found anything better.
