### PR TITLE
Remove post-blank after item elements

### DIFF
--- a/ox-jira.el
+++ b/ox-jira.el
@@ -99,6 +99,8 @@
   '(?j "Export to JIRA"
        ((?j "As JIRA buffer" ox-jira-export-as-jira))))
 
+;;; Internal Helpers
+
 (defun ox-jira--not-implemented (element-type)
   "Replace anything we don't handle yet wiht a big red marker."
   (format "{color:red}Element of type '%s' not implemented!{color}" element-type))
@@ -115,14 +117,13 @@ TREE is the parse tree being exported.  BACKEND is the export
 back-end used.  INFO is a plist used as a communication channel.
 
 Assume BACKEND is `jira'."
-  (org-element-map tree '(paragraph)
+  (org-element-map tree '(item paragraph)
     (lambda (e)
       (org-element-put-property
        e :post-blank
-       (if (and (eq (org-element-type e) 'paragraph)
-                (eq (org-element-type (org-element-property :parent e)) 'item))
-           0
-         1))))
+       (cond ((eq (org-element-type e) 'item) 0)
+             ((eq (org-element-type e) 'paragraph)
+              (if (eq (org-element-type (org-element-property :parent e)) 'item) 0 1))))))
   ;; Return updated tree.
   tree)
 
@@ -235,7 +236,7 @@ contextual information."
        (concat checkbox " "))
      (when tag
        (format "*%s*: " tag))
-     contents)))
+       contents)))
 
 (defun ox-jira-link (link desc info)
   "Transcode a LINK object from Org to JIRA.

--- a/ox-jira.org
+++ b/ox-jira.org
@@ -177,6 +177,10 @@
 
 ** Internal helpers
 
+   #+BEGIN_SRC emacs-lisp
+     ;;; Internal Helpers
+   #+END_SRC
+
    Because I'm adding support for things as I find I need it rather than all
    in one go, let's put a big fat red marker in for things we have not
    implemented yet, to avoid missing it.
@@ -202,7 +206,15 @@
 
    #+BEGIN_SRC emacs-lisp
      ;;; Filters
+   #+END_SRC
 
+   Org support a single blank line between items in a list, but if we export
+   like that to JIRA format it will be interpreted as multiple consecutive
+   lists, which is never what I want. We can attempt to fix this by removing
+   the "post-blank" after a items (and paragraphs inside items) using a
+   filter.
+
+   #+BEGIN_SRC emacs-lisp
      (defun ox-jira-fix-multi-paragraph-items (tree backend info)
        "Remove extra blank line between paragraphs in plain-list items.
 
@@ -210,14 +222,13 @@
      back-end used.  INFO is a plist used as a communication channel.
 
      Assume BACKEND is `jira'."
-       (org-element-map tree 'paragraph
+       (org-element-map tree '(item paragraph)
          (lambda (e)
            (org-element-put-property
             e :post-blank
-            (if (and (eq (org-element-type e) 'paragraph)
-                     (eq (org-element-type (org-element-property :parent e)) 'item))
-                0
-              1))))
+            (cond ((eq (org-element-type e) 'item) 0)
+                  ((eq (org-element-type e) 'paragraph)
+                   (if (eq (org-element-type (org-element-property :parent e)) 'item) 0 1))))))
        ;; Return updated tree.
        tree)
    #+END_SRC

--- a/test/ox-jira-test.org
+++ b/test/ox-jira-test.org
@@ -255,12 +255,27 @@
    #+BEGIN_SRC emacs-lisp
      (ert-deftest ox-jira-test/multi-para-list-items()
        (should (equal "# fi
-fo
-# fa
-" (org-export-string-as "1. fi
+     fo
+     # fa
+     " (org-export-string-as "1. fi
 
-   fo
-2. fa" 'jira))))
+        fo
+     2. fa" 'jira)))
+       (should (equal "# fi
+     #* fifi
+     #* fofo
+     # fa
+     # fum
+     " (org-export-string-as "1. fi
+
+       ,* fifi
+
+       ,* fofo
+
+     2. fa
+
+     3. fum" 'jira)))
+       )
    #+END_SRC
 
 ** Plain text


### PR DESCRIPTION
**Remove post-blank after item elements**
This means that Orgmode lists like this:
- fi
- fo
- fa

Exports to Jira:
- fi
- fo
- fa

which means it stays one list, rather than multiple.

Fixes #17

Credit: http://thread.gmane.org/gmane.emacs.orgmode/106478/focus=106480
