### PR TITLE
Make timestamps behave more like in ox-latex

### DIFF
--- a/ox-jira.el
+++ b/ox-jira.el
@@ -95,8 +95,7 @@
     (underline . ox-jira-underline)
     (verbatim . ox-jira-verbatim)
     (verse-block . (lambda (&rest args) (ox-jira--not-implemented 'verse-block))))
-  :filters-alist '((:filter-timestamp . ox-jira-remove-timestamp-brackets)
-                   (:filter-parse-tree . ox-jira-fix-multi-paragraph-items))
+  :filters-alist '((:filter-parse-tree . ox-jira-fix-multi-paragraph-items))
   :menu-entry
   '(?j "Export to JIRA"
        ((?j "As JIRA buffer" ox-jira-export-as-jira))))
@@ -484,15 +483,12 @@ holding contextual information."
 (defun ox-jira-timestamp (timestamp _contents info)
   "Transcode a TIMESTAMP object from Org to JIRA.
 CONTENTS is nil. INFO is a plist holding contextual information."
-  (let ((org-time-stamp-custom-formats '("<%Y-%m-%d>" . "<%Y-%m-%d %H:%M>"))
-        (org-display-custom-times t))
-    (org-timestamp-translate timestamp)))
-
-(defun ox-jira-remove-timestamp-brackets (timestamp backend info)
-  "Add a filter to remove annoying brackets around timestamps, as
-these are hardcoded in org-timestamp-translate, c.f.
-http://stackoverflow.com/a/33716338/5950"
-  (replace-regexp-in-string "[<>]\\|[][]" "" timestamp))
+  (let ((value (org-timestamp-translate timestamp))
+        (fmt (cl-case (org-element-property :type timestamp)
+               ((active active-range) "_%s_")
+               ((inactive inactive-range) "_\\%s_")
+               (otherwise "_%s_"))))
+    (format fmt value)))
 
 (defun ox-jira-export-as-jira
     (&optional async subtreep visible-only body-only ext-plist)

--- a/test/ox-jira-test.el
+++ b/test/ox-jira-test.el
@@ -313,12 +313,15 @@ h1. Footnotes
 [fn:2] fut fut.
 "))))
 
-
 (ert-deftest ox-jira-test/timestamps ()
-  (should (equal "An inactive timestamp: 2017-01-11\n"
-                 (to-jira "An inactive timestamp: [2017-01-11 Wed]")))
-  (should (equal "An active timestamp: 2017-01-11\n"
-                 (to-jira "An active timestamp: <2017-01-11 Wed>"))))
+  (should (equal "An inactive datestamp: _\\[2017-01-11 Wed]_\n"
+                 (to-jira "An inactive datestamp: [2017-01-11 Wed]")))
+  (should (equal "An inactive timestamp: _\\[2017-01-11 Wed 12:34]_\n"
+                 (to-jira "An inactive timestamp: [2017-01-11 Wed 12:34]")))
+  (should (equal "An active datestamp: _<2017-01-11 Wed>_\n"
+                 (to-jira "An active datestamp: <2017-01-11 Wed>")))
+  (should (equal "An active timestamp: _<2017-01-11 Wed 02:12>_\n"
+                 (to-jira "An active timestamp: <2017-01-11 Wed 02:12>"))))
 
 (provide 'ox-jira-test)
 


### PR DESCRIPTION
If no brackets are desired, one can make them non-timestamps (i.e. plain text)