### PR TITLE
link: handle custom-id and headling links

### DIFF
--- a/ox-jira.el
+++ b/ox-jira.el
@@ -284,6 +284,10 @@ INFO is a plist holding contextual information.  See
                  (concat type ":" raw-path))
                 ((string= type "file")
                  (org-export-file-uri raw-path))
+                ((string= type "custom-id")
+                 (if desc (concat "#" desc) (concat "#" raw-path)))
+                ((string-prefix-p "*" raw-path)
+                 (concat "#" (seq-subseq raw-path 1)))
                 (t raw-path))))
     (cond
      ;; Link with description

--- a/ox-jira.org
+++ b/ox-jira.org
@@ -492,6 +492,10 @@ but we must make a token effort. A lot of this code is cribbed from
                    (concat type ":" raw-path))
                   ((string= type "file")
                    (org-export-file-uri raw-path))
+                  ((string= type "custom-id")
+                   (if desc (concat "#" desc) (concat "#" raw-path)))
+                  ((string-prefix-p "*" raw-path)
+                   (concat "#" (seq-subseq raw-path 1)))
                   (t raw-path))))
       (cond
        ;; Link with description

--- a/test/ox-jira-test.el
+++ b/test/ox-jira-test.el
@@ -123,7 +123,15 @@ h1. {color:red}{{TODO}}{color} This is another headline {color:blue}{{:FOO:BAR:}
   (should (equal "fi [http://jira.atlassian.com] fo\n"
                  (to-jira "fi [[http://jira.atlassian.com]] fo")))
   (should (equal "fi [Jira|http://jira.atlassian.com] fo\n"
-                 (to-jira "fi [[http://jira.atlassian.com][Jira]] fo"))))
+                 (to-jira "fi [[http://jira.atlassian.com][Jira]] fo")))
+  (should (equal "see [#Heading Name] for details\n"
+                 (to-jira "see [[*Heading Name]] for details")))
+  (should (equal "see [This Thing|#Heading Name] for details\n"
+                 (to-jira "see [[*Heading Name][This Thing]] for details")))
+  (should (equal "see [#Heading Name] for details\n"
+                 (to-jira "see [[#Heading Name]] for details")))
+  (should (equal "see [This Thing|#This Thing] for details\n"
+                 (to-jira "see [[#Heading Name][This Thing]] for details"))))
 
 ;; Check that text in paragraphs does not have hard newlines.
 ;;


### PR DESCRIPTION
Hello! Thank you for such useful plugin!
I've added some functionality I need to generate confluence pages from my org files.

1. I use https://github.com/snosov1/toc-org plugin to automatically generate ToC tree on save hook, so there was need to convert heading links to atlassian anchors.
![image](https://user-images.githubusercontent.com/1115916/83908981-9ff48780-a770-11ea-8e88-b3955a76b4d1.png)

2. My friend used [[*Heading]] links in his articles, so I've implemented such thing too.

Tests included, all green =)

Signed-off-by: Pavel Kulyov <kulyov.pavel@gmail.com>