### PR TITLE
Support org-export-custom-protocol-maybe for links

### DIFF
--- a/ox-jira.el
+++ b/ox-jira.el
@@ -339,6 +339,7 @@ INFO is a plist holding contextual information.  See
                  (if desc (concat "#" desc) (concat "#" raw-path)))
                 ((string-prefix-p "*" raw-path)
                  (concat "#" (seq-subseq raw-path 1)))
+                ((org-export-custom-protocol-maybe link desc 'jira info))
                 (t raw-path))))
     (cond
      ;; Link with description

--- a/ox-jira.org
+++ b/ox-jira.org
@@ -562,6 +562,7 @@ INFO is a plist holding contextual information.  See
                  (if desc (concat "#" desc) (concat "#" raw-path)))
                 ((string-prefix-p "*" raw-path)
                  (concat "#" (seq-subseq raw-path 1)))
+                ((org-export-custom-protocol-maybe link desc 'jira info))
                 (t raw-path))))
     (cond
      ;; Link with description


### PR DESCRIPTION
This will trigger link exports directly from custom link packages if supported. 

An example of usage would be the orgit [1] package that supports
translating local magit git links to some http based repository viewer.

1. https://github.com/magit/orgit