### PR TITLE
Remove dependency on deprecated cl library

### DIFF
--- a/ox-jira.el
+++ b/ox-jira.el
@@ -35,7 +35,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 (require 'ox)
 (require 'ox-publish)
 (require 'subr-x)
@@ -306,7 +306,7 @@ contextual information."
          (tag (let ((tag (org-element-property :tag item)))
                 (when tag
                   (org-export-data tag info))))
-         (checkbox (case (org-element-property :checkbox item)
+         (checkbox (cl-case (org-element-property :checkbox item)
                      (on "(/)")
                      (off "(x)")
                      (trans "(i)"))))

--- a/ox-jira.org
+++ b/ox-jira.org
@@ -101,7 +101,7 @@ The first thing our code needs to do is require the libraries we need.
 I cargo-culted most of this from =ox-latex.el=.
 
 #+BEGIN_SRC emacs-lisp
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 (require 'ox)
 (require 'ox-publish)
 (require 'subr-x)
@@ -521,7 +521,7 @@ contextual information."
          (tag (let ((tag (org-element-property :tag item)))
                 (when tag
                   (org-export-data tag info))))
-         (checkbox (case (org-element-property :checkbox item)
+         (checkbox (cl-case (org-element-property :checkbox item)
                      (on "(/)")
                      (off "(x)")
                      (trans "(i)"))))


### PR DESCRIPTION
The cl library was deprecated in Emacs 27 and the usual recommendation is to
switch to cl-lib.